### PR TITLE
Одинаковые identicon в ленте fix

### DIFF
--- a/TabunAva Reborn.user.js
+++ b/TabunAva Reborn.user.js
@@ -416,7 +416,7 @@ function replaceTopicAuthorAvatars() {
     const imageNode = topicNode.querySelector('.avatar');
     if (!imageNode) return;
 
-    const usernameNode = document.querySelector("[rel=author]");
+    const usernameNode = topicNode.querySelector("[rel=author]");
     const username = usernameNode && usernameNode.textContent.trim();
     if (!username) return;
 


### PR DESCRIPTION
Исправлена ошибка "Кстати, лично у меня при просмотре ленты постов все айдэнтикон-аватарки у разных авторов одинаковые — уникальные айдэнтиконы подгружаются только при открытии."