### PR TITLE
Fix broken comment avatars

### DIFF
--- a/TabunAva Reborn.user.js
+++ b/TabunAva Reborn.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TabunAva Reborn
 // @namespace    http://tampermonkey.net/
-// @version      1.2.0
+// @version      1.3.0
 // @description  Установка своего аватара на Табуне!
 // @author       (IntelRug && (Kujivunia || Niko_de_Andjelo))
 // @match        https://tabun.everypony.ru/*
@@ -629,10 +629,8 @@ function replaceCommentAvatars() {
     const authorNode = commentNode.querySelector('.comment-author');
     const username = authorNode && authorNode.textContent.trim();
     if (!username) return;
-
-    const imageNode = authorNode && authorNode.querySelector('img');
+    const imageNode = commentNode.querySelector('img.comment-avatar');
     if (!imageNode) return;
-
     replaceAvatarInImageNode(imageNode, username);
   });
 }


### PR DESCRIPTION
After recent tabun update, DOM has changed for comment area (corresponding `<img>` is no more inside `.comment-author`), so the script has to be updated to support this.